### PR TITLE
editing message to console so the realization and lifecycle number matches the missing records.  No longer assumes realization starts at 1

### DIFF
--- a/DCInvestigator.props
+++ b/DCInvestigator.props
@@ -1,1 +1,2 @@
 SimulationName,Validation
+TotalRealizations,25

--- a/src/main/java/DCInvestigatorSettings.java
+++ b/src/main/java/DCInvestigatorSettings.java
@@ -19,9 +19,15 @@ import java.util.ArrayList;
  */
 public class DCInvestigatorSettings {
     private String _SimulationName;//the simulation the user wishes to check on
+    private String _TotalRealizations;
+
     public String getSimulation(){
         return _SimulationName;
     }
+    public String getTotalRealizations() {return _TotalRealizations; }
+
+
+
     public DCInvestigatorSettings(String propertiesPath){
         //read in the properties file?
         String propertiesFile = propertiesPath;
@@ -37,6 +43,9 @@ public class DCInvestigatorSettings {
                     if(tmp.length==0){continue;}
                     if(tmp[0].equals("SimulationName")){
                         _SimulationName = tmp[1];
+                    }
+                    if(tmp[0].equals("TotalRealizations")){
+                        _TotalRealizations = tmp[1];
                     }
                 }
             } catch (FileNotFoundException e) {

--- a/src/test/java/DCInvestigatorSettingsTest.java
+++ b/src/test/java/DCInvestigatorSettingsTest.java
@@ -12,4 +12,10 @@ class DCInvestigatorSettingsTest {
         String actual = settings.getSimulation();
         assertEquals("Validation", actual);
     }
+
+    @Test
+    void getTotalRealizations() {
+        String actual = settings.getTotalRealizations();
+        assertEquals("25", actual);
+    }
 }


### PR DESCRIPTION
previous code appeared to assume realization starts at 0.  Made an edit to extract the starting realization value from a dss record.  Not sure if this is the best way to do this.  